### PR TITLE
Fix test for helper.bats

### DIFF
--- a/test/helper.bats
+++ b/test/helper.bats
@@ -13,11 +13,11 @@ teardown() {
 @test "Check first run" {
     NON_EXISTANT_FIRST_RUN_FILE=$(mktemp -u) # only create the name, not the file itself
 
-    assert _is_first_run
-    refute _is_first_run
-    refute _is_first_run
+    assert _is_first_run "$NON_EXISTANT_FIRST_RUN_FILE"
+    refute _is_first_run "$NON_EXISTANT_FIRST_RUN_FILE"
+    refute _is_first_run "$NON_EXISTANT_FIRST_RUN_FILE"
 
     EXISTING_FIRST_RUN_FILE=$(mktemp)
-    refute _is_first_run
-    refute _is_first_run
+    refute _is_first_run "$EXISTING_FIRST_RUN_FILE"
+    refute _is_first_run "$EXISTING_FIRST_RUN_FILE"
 }


### PR DESCRIPTION
This aims to provide a fix for the failing `helper` test. I'm assuming the author's intention based on the `_is_first_run` signature, since it supports a "first run file" being passed as a parameter.